### PR TITLE
fix silent disk read failures in .exec

### DIFF
--- a/kernel/kernel.asm
+++ b/kernel/kernel.asm
@@ -204,6 +204,7 @@ syscall_handler:
     mov cl, al             ; sector number from caller
     mov ax, 0x0201         ; read 1 sector
     int 0x13
+    jc .disk_error
 
     pop es
     pop dx
@@ -211,6 +212,11 @@ syscall_handler:
     pop bx
     pop ax
     jmp 0x3000:0000
+
+.disk_error:
+    mov si, disk_err_msg
+    call print_string
+    jmp $
 
 .done:
     pop es


### PR DESCRIPTION
## Description

### Fixes silent disk read failures in the `.exec` routine of `kernel.asm` (#10)
Previously, the routine did not check the `carry flag` after invoking `INT 13h`, which meant disk errors were ignored and execution continued unpredictably. This resulted in silent failures when loading code from disk.


## Changes Made
- Added a `jc .disk_error` check after the `INT 13h` call in `.exec`.
- Introduced a dedicated `.disk_error` handler.