### PR TITLE
fix(build): auto-create BUILD_DIR and remove it when cleaned

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,22 +17,26 @@ ASMFLAGS = -f bin
 # Targets
 all: $(FLOPPY_IMG)
 
-$(FLOPPY_IMG): $(BOOTLOADER_BIN) $(KERNEL_BIN) $(SHELL_BIN)
+# Ensure build directory exists
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+$(FLOPPY_IMG): $(BOOTLOADER_BIN) $(KERNEL_BIN) $(SHELL_BIN) | $(BUILD_DIR)
 	dd if=/dev/zero of=$(FLOPPY_IMG) bs=512 count=2880
 	dd if=$(BOOTLOADER_BIN) of=$(FLOPPY_IMG) bs=512 seek=0 conv=notrunc
 	dd if=$(KERNEL_BIN)     of=$(FLOPPY_IMG) bs=512 seek=1 conv=notrunc
 	dd if=$(SHELL_BIN)      of=$(FLOPPY_IMG) bs=512 seek=3 conv=notrunc
 
-$(BOOTLOADER_BIN): $(BOOTLOADER_DIR)/boot.asm
+$(BOOTLOADER_BIN): $(BOOTLOADER_DIR)/boot.asm | $(BUILD_DIR)
 	$(ASM) $(ASMFLAGS) $< -o $@
 
-$(KERNEL_BIN): $(KERNEL_DIR)/kernel.asm
+$(KERNEL_BIN): $(KERNEL_DIR)/kernel.asm | $(BUILD_DIR)
 	$(ASM) $(ASMFLAGS) $< -o $@
 
-$(SHELL_BIN): $(USER_DIR)/shell.asm
+$(SHELL_BIN): $(USER_DIR)/shell.asm | $(BUILD_DIR)
 	$(ASM) $(ASMFLAGS) $< -o $@
 
 clean:
-	rm -f $(BUILD_DIR)/*.bin $(FLOPPY_IMG)
+	rm -rf $(BUILD_DIR)
 
 .PHONY: all clean


### PR DESCRIPTION
## Description
## Fixes build failures when the `build/` directory does not exist (fixes #13)
- `Makefile` assumes that `$(BUILD_DIR) already exists and the output is written under it.
- On a fresh clone running `make` fails because `nasm` and `dd` can't write to a **non-existent directory**.

This PR fixes the problem by automatically creating `$(BUILD_DIR)` prior to building outputs.

## Changes
- Added an **order‑only prerequisite** for `$(BUILD_DIR)` to ensure the directory is created automatically.  
- Updated the `clean target` to remove the entire `$(BUILD_DIR)` directory

## Ouput after fix
<img width="1235" height="788" alt="image" src="https://github.com/user-attachments/assets/22625c00-49c3-41c0-8b86-add5f965c653" />
