### PR TITLE
build(makefile): add QEMU run and debug targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+# Emulator settings: ISA-only machine, 1MB real-mode memory, floppy boot
+QEMU = qemu-system-i386
+QEMUFLAGS = -M isapc -m 1M -cpu 486 \
+            -drive file=$(FLOPPY_IMG),format=raw,if=floppy \
+            -boot a
+
 # Directories
 BOOTLOADER_DIR = bootloader
 KERNEL_DIR     = kernel
@@ -36,7 +42,13 @@ $(KERNEL_BIN): $(KERNEL_DIR)/kernel.asm | $(BUILD_DIR)
 $(SHELL_BIN): $(USER_DIR)/shell.asm | $(BUILD_DIR)
 	$(ASM) $(ASMFLAGS) $< -o $@
 
+run: all
+	$(QEMU) $(QEMUFLAGS)
+
+run-debug: all
+	$(QEMU) $(QEMUFLAGS) -S -s
+
 clean:
 	rm -rf $(BUILD_DIR)
 
-.PHONY: all clean
+.PHONY: all run run-debug clean


### PR DESCRIPTION
## Description
### Add `run` & `run-debug` targets for QEMU-based boot and debugging (#18)
- `run` target builds the project and boots the generated floppy image in QEMU using a legacy ISA-based x86 configuration.
-  `run-debug` performs the same flow with the **QEMU GDB stub** enabled (`-S -s`) for early boot debugging

## Emulator settings
```
QEMU = qemu-system-i386
QEMUFLAGS = -M isapc -m 1M -cpu 486 \
            -drive file=$(FLOPPY_IMG),format=raw,if=floppy \
            -boot a
```
- legacy ISA only machine
- `486` CPU selected since QEMU doesn't provide an `8086` CPU model (real mode execution remains 8086-compatible)
- 1MB real mode
- floppy-based boot
