### PR TITLE
[BUG FIX] Add backspace handling to read_line

### DIFF
--- a/user/shell.asm
+++ b/user/shell.asm
@@ -31,6 +31,8 @@ read_line:
     je .read_char
     cmp al, 0x0D
     je .done
+    cmp al, 0x08        ; Backspace?
+    je .handle_backspace
     cmp di, buffer_size
     jae .buffer_full
     mov [line_buffer + di], al
@@ -38,6 +40,24 @@ read_line:
     mov ah, 0x02
     int 0x60
     jmp .read_char
+
+.handle_backspace:
+    cmp di, 0       ; Buffer empty?
+    je .read_char
+    dec di          ; Remove the buffer
+
+    ; Erase from screen: backspace, space, backspace
+    mov al, 0x08
+    mov ah, 0x02
+    int 0x60
+    mov al, ' '
+    mov ah, 0x02
+    int 0x60
+    mov al, 0x08
+    mov ah, 0x02
+    int 0x60
+    jmp .read_char
+
 .buffer_full:
     cmp byte [buffer_warned], 1
     je .read_char       ; skip warning if already warned


### PR DESCRIPTION
## Descriptiption
### Problem
The shell's `read_line` function had no backspace handling:
- Pressing backspace moved cursor backwards but didn't delete characters
- Characters remained in the buffer
- Typing would overwrite characters on screen
- No way to correct typing mistakes

The backspace character (`0x08`) was being echoed to screen like any other character, which only moved the cursor backwards without erasing anything.

Fixes #9 

## Test
https://github.com/user-attachments/assets/ee674a6d-f066-49ef-a211-f52735224383

## Changes Made
### Input Flow
- Check for backspace **before** echoing character to screen
- Only echo normal characters, skip special keys like backspace and Enter

### Backspace Handler (`.handle_backspace`)
- Check if buffer is empty (prevent deletion on empty input)
- Decrement buffer index (`di`) to remove character from buffer
- Implement proper character erasure sequence:
  - **Print backspace** (move cursor left)
  - **Print space** (erase character visually)
  - **Print backspace** again (reposition cursor)