### PR TITLE
[WIP] feat(kernel): extend keyboard support with modifiers and special keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ $(FLOPPY_IMG): $(BOOTLOADER_BIN) $(KERNEL_BIN) $(SHELL_BIN) | $(BUILD_DIR)
 	dd if=/dev/zero of=$(FLOPPY_IMG) bs=512 count=2880
 	dd if=$(BOOTLOADER_BIN) of=$(FLOPPY_IMG) bs=512 seek=0 conv=notrunc
 	dd if=$(KERNEL_BIN)     of=$(FLOPPY_IMG) bs=512 seek=1 conv=notrunc
-	dd if=$(SHELL_BIN)      of=$(FLOPPY_IMG) bs=512 seek=3 conv=notrunc
+	dd if=$(SHELL_BIN)      of=$(FLOPPY_IMG) bs=512 seek=4 conv=notrunc
 
 $(BOOTLOADER_BIN): $(BOOTLOADER_DIR)/boot.asm | $(BUILD_DIR)
 	$(ASM) $(ASMFLAGS) $< -o $@

--- a/bootloader/boot.asm
+++ b/bootloader/boot.asm
@@ -11,8 +11,8 @@ start:
 
     mov ax, 0x0800
     mov es, ax
-    mov ax, 0x0202        ; INT 13h: read 2 sectors
-    mov cx, 0x0002        
+    mov ax, 0x0203        ; INT 13h: read 3 sectors
+    mov cx, 0x0002
     mov bx, 0x0000
     mov dx, 0x0000
     int 0x13

--- a/kernel/kernel.asm
+++ b/kernel/kernel.asm
@@ -79,7 +79,7 @@ keyboard_handler:
     mov es, ax
 
     in al, 0x60
-    cmp al, 58
+    cmp al, 0x53
     ja .done
 
     xor ah, ah
@@ -559,10 +559,18 @@ load_shell:
 ; Scancode to ASCII Table
 ; -------------------------------
 scancode_table:
+    ; 0x00-0x0F
     db 0, 27, '1','2','3','4','5','6','7','8','9','0','-','=', 8, 9
+    ; 0x10-0x1F (Q-P, Enter, Ctrl, A-L)
     db 'q','w','e','r','t','y','u','i','o','p','[',']',13, 0,'a','s'
-    db 'd','f','g','h','j','k','l',';',39,'`','\\','z','x','c','v'
-    db 'b','n','m',',','.','/', 0, '*', 0, ' '
+    ; 0x20-0x2F (D-M, Left Shift, \, Z-M)
+    db 'd','f','g','h','j','k','l',';',39,'`', 0,'\\','z','x','c','v'
+    ; 0x30-0x3F (B-/, Right Shift, Keypad *, Alt, Space, Caps, F1-F6)
+    db 'b','n','m',',','.','/', 0, '*', 0, ' ', 0, 0, 0, 0, 0, 0
+    ; 0x40-0x4F (F7-F10, Num Lock, Scroll Lock, Keypad 7-1)
+    db 0, 0, 0, 0, 0, 0, 0, '7', '8', '9', '-', '4', '5', '6', '+', '1'
+    ; 0x50-0x53 (Keypad 2, 3, 0, .)
+    db '2', '3', '0', '.'
 
 ; -------------------------------
 ; Boot Message

--- a/kernel/kernel.asm
+++ b/kernel/kernel.asm
@@ -96,6 +96,14 @@ keyboard_handler:
     cmp al, 0x36
     je .right_shift_press
 
+    ; Check for Left Ctrl press (0x1D)
+    cmp al, 0x1D
+    je .left_ctrl_press
+
+    ; Check for Left Alt press (0x38)
+    cmp al, 0x38
+    je .left_alt_press
+
     ; Normal key - check if shift is pressed
     mov cl, [shift_pressed]
     test cl, cl
@@ -128,6 +136,14 @@ keyboard_handler:
     or byte [shift_pressed], 0x02   ; set bit 1
     jmp .done
 
+.left_ctrl_press:
+    or byte [ctrl_pressed], 0x01    ; set bit 0
+    jmp .done
+
+.left_alt_press:
+    or byte [alt_pressed], 0x01     ; set bit 0
+    jmp .done
+
 .key_release:
     ; Remove break bit to get make code
     and al, 0x7F
@@ -140,6 +156,14 @@ keyboard_handler:
     cmp al, 0x36
     je .right_shift_release
 
+    ; Check for Left Ctrl release
+    cmp al, 0x1D
+    je .left_ctrl_release
+
+    ; Check for Left Alt release
+    cmp al, 0x38
+    je .left_alt_release
+
     jmp .done
 
 .left_shift_release:
@@ -148,6 +172,14 @@ keyboard_handler:
 
 .right_shift_release:
     and byte [shift_pressed], 0xFD      ; Clear bit 1
+    jmp .done
+
+.left_ctrl_release:
+    and byte [ctrl_pressed], 0xFE       ; Clear bit 0
+    jmp .done
+
+.left_alt_release:
+    and byte [alt_pressed], 0xFE        ; Clear bit 0
     jmp .done
 
 .done:

--- a/kernel/kernel.asm
+++ b/kernel/kernel.asm
@@ -717,7 +717,7 @@ load_shell:
     mov es, ax
     mov ax, 0x0201
     mov bx, 0x0000
-    mov cx, 0x0004
+    mov cx, 0x0005          ; Start reading shell from sector 5
     mov dx, 0x0000
     int 0x13
     jc .error


### PR DESCRIPTION
#### Extend keyboard handler with `Shift`, `Left Ctrl`, `Left Alt`, tracking & `Caps Lock` toggle

Addresses #32

### Shift key tracking
- Left/Right Shift press/release detection working
- Added `shift_pressed` state flag (bitmask: bit 0 = left, bit 1 = right)
- Created `scancode_table_shift` with uppercase letters and shifted symbols

### Ctrl and Alt tracking
- Left Ctrl and Left Alt press/release detection
- Added `ctrl_pressed` and `alt_pressed` state flags
- Modifier keys don't generate characters (correct behavior)